### PR TITLE
braket native and ir conversion

### DIFF
--- a/qcware_transpile/dialects/braket/__init__.py
+++ b/qcware_transpile/dialects/braket/__init__.py
@@ -1,5 +1,5 @@
 """
 AWS Braket is Amazon's quantum-on-the-cloud service.
 """
-# from .braket_dialect import (dialect, native_to_ir, ir_to_native,
-#                              native_circuits_are_equivalent, audit)
+from .braket_dialect import (dialect, native_to_ir, ir_to_native,
+                              native_circuits_are_equivalent) #, audit)

--- a/tests/dialects/test_braket.py
+++ b/tests/dialects/test_braket.py
@@ -1,0 +1,11 @@
+from ..strategies.braket import circuits
+from braket.circuits import Circuit
+from qcware_transpile.dialects.braket import (native_to_ir, ir_to_native, native_circuits_are_equivalent)
+from hypothesis import given, note, settings
+
+@given(circuits(min_qubits=1, max_qubits=4, min_length=1, max_length=3))
+@settings(deadline=None)
+def test_conversion(qc):
+    c = native_to_ir(qc)
+    qc2 = ir_to_native(c)
+    assert native_circuits_are_equivalent(qc, qc2)


### PR DESCRIPTION
Add `native_to_ir`, `ir_to_native`, `native_circuits_are_equivalent`, several helper methods, and conversion tests for braket. 