### PR TITLE
Q# measurement

### DIFF
--- a/qcware_transpile/dialects/qsharp/qsharp_dialect.py
+++ b/qcware_transpile/dialects/qsharp/qsharp_dialect.py
@@ -58,19 +58,31 @@ def ir_to_native(c: Circuit) -> str:
     result = Template("""
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Measurement;
     open Microsoft.Quantum.Diagnostics as Diagnostics;
 
-    operation TestCircuit(): Unit {
-
-        use qs = Qubit[{{num_qubits}}];
+    operation PrepareState(qs: Qubit[]): Unit {
 
         {% for operation in operations %} 
         {{operation}}; 
         {% endfor %}
 
-        Diagnostics.DumpMachine("{{ output_file }}");
+    }
 
+    operation DumpToFile(): Unit {
+
+        use qs = Qubit[{{num_qubits}}];
+        PrepareState(qs);
+        Diagnostics.DumpMachine("{{ output_file }}");
         ResetAll(qs);
+    }
+
+    operation Measure(): Result[] {
+
+        use qs = Qubit[{{num_qubits}}];
+        PrepareState(qs);
+        return MultiM(qs);
+
     }
     """)
     return result.render(num_qubits=max(c.qubits)+1, operations=operations, output_file="{{ output_file }}")

--- a/qcware_transpile/dialects/qsharp/qsharp_dialect.py
+++ b/qcware_transpile/dialects/qsharp/qsharp_dialect.py
@@ -64,13 +64,10 @@ def ir_to_native(c: Circuit) -> str:
 
         use qs = Qubit[{{num_qubits}}];
 
-        Message("Initial state |000>:");
-
         {% for operation in operations %} 
         {{operation}}; 
         {% endfor %}
 
-        Message("After:");
         Diagnostics.DumpMachine("{{ output_file }}");
 
         ResetAll(qs);

--- a/tests/strategies/qsharp/__init__.py
+++ b/tests/strategies/qsharp/__init__.py
@@ -38,20 +38,33 @@ def circuits(draw, min_qubits, max_qubits, min_length, max_length):
     circuit_gates = draw(
         lists(gates(num_qubits), min_size=length, max_size=length))
     result = Template("""
+    open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Measurement;
     open Microsoft.Quantum.Diagnostics as Diagnostics;
 
-    operation TestCircuit(): Unit {
+    operation PrepareState(qs: Qubit[]): Unit {
+
+        {% for operation in operations %} 
+        {{operation}}; 
+        {% endfor %}
+
+    }
+
+    operation DumpToFile(): Unit {
 
         use qs = Qubit[{{num_qubits}}];
-
-        {% for gate in circuit_gates %} 
-        {{gate}}; 
-        {% endfor %}
-        
+        PrepareState(qs);
         Diagnostics.DumpMachine("{{ output_file }}");
-
         ResetAll(qs);
+    }
+
+    operation Measure(): Result[] {
+
+        use qs = Qubit[{{num_qubits}}];
+        PrepareState(qs);
+        return MultiM(qs);
+        
     }
     """)
     return result.render(num_qubits=num_qubits, circuit_gates=circuit_gates, output_file="{{ output_file }}")
@@ -63,10 +76,11 @@ def parse_dump_machine(lines):
     values = [complex(entry[1], entry[2]) for entry in entries]
     return numpy.array(values)
 
+
 def run_generated_circuit(qc_nooutput):
     with tempfile.NamedTemporaryFile(mode="w+") as f:
         qc = Template(qc_nooutput).render(output_file=f.name)
-        compile(qc).simulate()
+        compile(qc)[1].simulate()
         lines = f.readlines()
         result = parse_dump_machine(lines)
     return result

--- a/tests/strategies/qsharp/__init__.py
+++ b/tests/strategies/qsharp/__init__.py
@@ -45,13 +45,10 @@ def circuits(draw, min_qubits, max_qubits, min_length, max_length):
 
         use qs = Qubit[{{num_qubits}}];
 
-        Message("Initial state |000>:");
-
         {% for gate in circuit_gates %} 
         {{gate}}; 
         {% endfor %}
-
-        Message("After:");
+        
         Diagnostics.DumpMachine("{{ output_file }}");
 
         ResetAll(qs);

--- a/tests/translations/quasar/test_to_qsharp.py
+++ b/tests/translations/quasar/test_to_qsharp.py
@@ -5,7 +5,6 @@ from qcware_transpile.dialects import qsharp as qsharp_dialect, quasar as quasar
 from qcware_transpile.circuits import reverse_circuit
 from ...strategies.quasar import gates, circuits
 from ...strategies.qsharp import run_generated_circuit
-from qsharp import compile
 import quasar
 import numpy
 


### PR DESCRIPTION
Modify the Q# program template returned by `ir_to_native` in `qcware_transpile/dialects/qsharp_dialect.py` by dividing it into three callables: `PrepareState`, `DumpToFile`, and `Measure`. Modify `tests/strategies/qsharp/__init__.py` to test simulation of `DumpToFile`.