### PR TITLE
Q# measurement changes

### DIFF
--- a/tests/strategies/qsharp/__init__.py
+++ b/tests/strategies/qsharp/__init__.py
@@ -66,7 +66,6 @@ def measure_circuit(qc: str, shots: int):
     result = {str(list(p)).replace(' ', ''): 0 for p in product(range(2), repeat=num_qubits)}
     for i in range(shots):
         x = ops['Measure'].simulate()
-        print(x)
         result[str(x).replace(' ', '')] += 1
     for k, v in result.items():
         result[k] = v/shots

--- a/tests/translations/quasar/test_to_qsharp.py
+++ b/tests/translations/quasar/test_to_qsharp.py
@@ -59,6 +59,9 @@ def test_measurement(shots=1000):
     qsharp_circuit = thread_first(
                                   circuit, 
                                   quasar_dialect.native_to_ir,
+                                  # reverse the bit order in the ir quasar circuit
+                                  # since quasar uses big-endian representation and
+                                  # qsharp uses little-endian representation
                                   reverse_circuit, 
                                   lambda x: simple_translate(translation_set(), x), 
                                   qsharp_dialect.ir_to_native
@@ -77,6 +80,11 @@ def test_measurement(shots=1000):
     qsharp_result = measure_circuit(qc=qsharp_circuit, 
                                     shots=shots)
     histogram = {
+        # reverse the bit order of each key in the histogram 
+        # because although qsharp uses little-endian 
+        # (most significant digit first) for representing
+        # states in the statevector, it returns measurements
+        # in index order (least significant digit first)
         int_from_binstr(binlist_from_binstr(k)[::-1]): v 
         for k, v in qsharp_result.items()
     }


### PR DESCRIPTION
Q# uses little-endian (most significant digit first) to represent states in a statevector. However, it uses index order (least significant digit first) when returning measurements. We bit-reverse circuits before translation to qsharp in order to return a statevector that matches the statevector returned by quasar. Therefore, in order to return a probability histogram that matches the probability histogram returned by quasar, we must reverse the bits of each key in the measurement histogram returned by Q# 